### PR TITLE
[ASE-731] openapi integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,5 +70,10 @@
             <artifactId>minio</artifactId>
             <version>8.5.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.13</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/ase/exagrad/studentservice/component/ApiResponseFactory.java
+++ b/src/main/java/com/ase/exagrad/studentservice/component/ApiResponseFactory.java
@@ -2,7 +2,7 @@ package com.ase.exagrad.studentservice.component;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.ApiResponseWrapper;
 import com.ase.exagrad.studentservice.dto.response.ErrorDetails;
 import lombok.RequiredArgsConstructor;
 
@@ -12,8 +12,8 @@ public class ApiResponseFactory {
 
   private final TimeProvider timeProvider;
 
-  public <T> ApiResponse<T> success(T data, String endpoint, HttpStatus httpStatus) {
-    return ApiResponse.<T>builder()
+  public <T> ApiResponseWrapper<T> success(T data, String endpoint, HttpStatus httpStatus) {
+    return ApiResponseWrapper.<T>builder()
         .success(true)
         .statusCode(httpStatus.value())
         .status(httpStatus.getReasonPhrase())
@@ -23,17 +23,17 @@ public class ApiResponseFactory {
         .build();
   }
 
-  public <T> ApiResponse<T> success(T data, String endpoint) {
+  public <T> ApiResponseWrapper<T> success(T data, String endpoint) {
     return success(data, endpoint, HttpStatus.OK);
   }
 
-  public <T> ApiResponse<T> created(T data, String endpoint) {
+  public <T> ApiResponseWrapper<T> created(T data, String endpoint) {
     return success(data, endpoint, HttpStatus.CREATED);
   }
 
-  public <T> ApiResponse<T> error(
+  public <T> ApiResponseWrapper<T> error(
       String message, String endpoint, HttpStatus httpStatus, ErrorDetails errorDetails) {
-    return ApiResponse.<T>builder()
+    return ApiResponseWrapper.<T>builder()
         .success(false)
         .statusCode(httpStatus.value())
         .status(httpStatus.getReasonPhrase())
@@ -44,7 +44,7 @@ public class ApiResponseFactory {
         .build();
   }
 
-  public <T> ApiResponse<T> badRequest(String message, String endpoint) {
+  public <T> ApiResponseWrapper<T> badRequest(String message, String endpoint) {
     return error(
         message,
         endpoint,
@@ -52,7 +52,7 @@ public class ApiResponseFactory {
         ErrorDetails.builder().code("VALIDATION_ERROR").message(message).build());
   }
 
-  public <T> ApiResponse<T> internalServerError(String message, String endpoint) {
+  public <T> ApiResponseWrapper<T> internalServerError(String message, String endpoint) {
     return error(
         message,
         endpoint,

--- a/src/main/java/com/ase/exagrad/studentservice/config/MinioConnectionProperties.java
+++ b/src/main/java/com/ase/exagrad/studentservice/config/MinioConnectionProperties.java
@@ -1,8 +1,8 @@
 package com.ase.exagrad.studentservice.config;
 
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-import lombok.Data;
 
 @Data
 @Component

--- a/src/main/java/com/ase/exagrad/studentservice/config/MinioConnectionProperties.java
+++ b/src/main/java/com/ase/exagrad/studentservice/config/MinioConnectionProperties.java
@@ -1,8 +1,8 @@
 package com.ase.exagrad.studentservice.config;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import lombok.Data;
 
 @Data
 @Component

--- a/src/main/java/com/ase/exagrad/studentservice/config/OpenApiConfig.java
+++ b/src/main/java/com/ase/exagrad/studentservice/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.ase.exagrad.studentservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("ExaGrad Student Service API")
+            .version("1.0.0")
+            .description("API for managing exam documents and PUB documents (Prüfungsunfähigkeitsdokumente) for students")
+            .contact(new Contact()
+                .name("ASE Team 13")
+                .email("simon.dietrich@stud-provadis-hochschule.de")));
+  }
+}

--- a/src/main/java/com/ase/exagrad/studentservice/controller/ExamDocumentController.java
+++ b/src/main/java/com/ase/exagrad/studentservice/controller/ExamDocumentController.java
@@ -13,24 +13,39 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import com.ase.exagrad.studentservice.component.ApiResponseFactory;
 import com.ase.exagrad.studentservice.dto.request.ExamDocumentRequest;
-import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.ApiResponseWrapper;
 import com.ase.exagrad.studentservice.dto.response.ExamDocumentResponse;
 import com.ase.exagrad.studentservice.service.ExamDocumentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/documents/exams")
 @RequiredArgsConstructor
+@Tag(name = "Exam Documents", description = "Operations for managing exam documents")
 public class ExamDocumentController {
 
   private final ExamDocumentService examDocumentService;
   private final ApiResponseFactory apiResponseFactory;
 
-  @PostMapping(consumes = {"multipart/form-data"})
-  public ResponseEntity<ApiResponse<ExamDocumentResponse>> uploadExamDocument(
-      @RequestPart("file") MultipartFile file,
-      @RequestPart("metadata") ExamDocumentRequest metadata,
+  @PostMapping(consumes = {"multipart/form-data", "application/octet-stream"})
+  @Operation(summary = "Upload exam document", description = "Upload an exam document with metadata")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Document uploaded successfully",
+          content = @Content(schema = @Schema(implementation = ExamDocumentResponse.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid input"),
+      @ApiResponse(responseCode = "500", description = "Internal server error")
+  })
+  public ResponseEntity<ApiResponseWrapper<ExamDocumentResponse>> uploadExamDocument(
+      @Parameter(description = "Document file to upload") @RequestPart("file") MultipartFile file,
+      @Parameter(description = "Document metadata") @RequestPart("metadata") ExamDocumentRequest metadata,
       HttpServletRequest request) {
 
     try {
@@ -53,13 +68,18 @@ public class ExamDocumentController {
   }
 
   @GetMapping
-  public ResponseEntity<ApiResponse<List<ExamDocumentResponse>>> getDocuments(
-      @RequestParam(required = false) String studentId,
-      @RequestParam(required = false) String examId,
+  @Operation(summary = "Get exam documents", description = "Get exam documents by student ID or exam ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Documents retrieved successfully"),
+      @ApiResponse(responseCode = "400", description = "Invalid parameters")
+  })
+  public ResponseEntity<ApiResponseWrapper<List<ExamDocumentResponse>>> getDocuments(
+      @Parameter(description = "Student ID to filter documents") @RequestParam(required = false) String studentId,
+      @Parameter(description = "Exam ID to filter documents") @RequestParam(required = false) String examId,
       HttpServletRequest request) {
 
-    if ((studentId != null && !studentId.isEmpty() && examId != null && !examId.isEmpty())
-        || ((studentId == null || studentId.isEmpty()) && (examId == null || examId.isEmpty()))) {
+    if ((studentId!=null && !studentId.isEmpty() && examId!=null && !examId.isEmpty())
+        || ((studentId==null || studentId.isEmpty()) && (examId==null || examId.isEmpty()))) {
       return ResponseEntity.badRequest()
           .body(
               apiResponseFactory.badRequest(
@@ -68,9 +88,9 @@ public class ExamDocumentController {
     }
 
     List<ExamDocumentResponse> documents =
-        (studentId != null && !studentId.isEmpty())
+        (studentId!=null && !studentId.isEmpty())
             ? examDocumentService.getDocumentsByStudentId(studentId)
-            : examDocumentService.getDocumentsByExamId(examId);
+            :examDocumentService.getDocumentsByExamId(examId);
 
     return ResponseEntity.ok(apiResponseFactory.success(documents, request.getRequestURI()));
   }

--- a/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
+++ b/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
@@ -1,12 +1,7 @@
 package com.ase.exagrad.studentservice.controller;
 
-import com.ase.exagrad.studentservice.component.ApiResponseFactory;
-import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
-import com.ase.exagrad.studentservice.dto.response.ApiResponse;
-import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
-import com.ase.exagrad.studentservice.service.PubDocumentService;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +11,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
-import java.util.List;
+import com.ase.exagrad.studentservice.component.ApiResponseFactory;
+import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
+import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
+import com.ase.exagrad.studentservice.service.PubDocumentService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/documents/pub")

--- a/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
+++ b/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
@@ -55,22 +55,17 @@ public class PubDocumentController {
   @GetMapping
   public ResponseEntity<ApiResponse<List<PubDocumentResponse>>> getDocuments(
       @RequestParam(required = false) String studentId,
-      @RequestParam(required = false) String pubId,
       HttpServletRequest request) {
 
-    if ((studentId != null && !studentId.isEmpty() && pubId != null && !pubId.isEmpty())
-        || ((studentId == null || studentId.isEmpty()) && (pubId == null || pubId.isEmpty()))) {
+    if (studentId == null || studentId.isEmpty()) {
       return ResponseEntity.badRequest()
           .body(
               apiResponseFactory.badRequest(
-                  "Provide exactly one parameter: studentId OR pubId",
+                  "Parameter studentId is required",
                   request.getRequestURI()));
     }
 
-    List<PubDocumentResponse> documents =
-        (studentId != null && !studentId.isEmpty())
-            ? pubDocumentService.getDocumentsByStudentId(studentId)
-            : pubDocumentService.getDocumentsByPubId(pubId);
+    List<PubDocumentResponse> documents = pubDocumentService.getDocumentsByStudentId(studentId);
 
     return ResponseEntity.ok(apiResponseFactory.success(documents, request.getRequestURI()));
   }

--- a/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
+++ b/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
@@ -13,24 +13,39 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import com.ase.exagrad.studentservice.component.ApiResponseFactory;
 import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
-import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.ApiResponseWrapper;
 import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
 import com.ase.exagrad.studentservice.service.PubDocumentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/documents/pub")
 @RequiredArgsConstructor
+@Tag(name = "PUB Documents", description = "Operations for managing Prüfungsunfähigkeitsdokumente (examination incapacity documents)")
 public class PubDocumentController {
 
   private final PubDocumentService pubDocumentService;
   private final ApiResponseFactory apiResponseFactory;
 
-  @PostMapping(consumes = {"multipart/form-data"})
-  public ResponseEntity<ApiResponse<PubDocumentResponse>> uploadPubDocument(
-      @RequestPart("file") MultipartFile file,
-      @RequestPart("metadata") PubDocumentRequest metadata,
+  @PostMapping(consumes = {"multipart/form-data", "application/octet-stream"})
+  @Operation(summary = "Upload PUB document", description = "Upload a Prüfungsunfähigkeitsdokument (examination incapacity document) with metadata")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Document uploaded successfully",
+          content = @Content(schema = @Schema(implementation = PubDocumentResponse.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid input"),
+      @ApiResponse(responseCode = "500", description = "Internal server error")
+  })
+  public ResponseEntity<ApiResponseWrapper<PubDocumentResponse>> uploadPubDocument(
+      @Parameter(description = "PUB document file to upload") @RequestPart("file") MultipartFile file,
+      @Parameter(description = "Document metadata") @RequestPart("metadata") PubDocumentRequest metadata,
       HttpServletRequest request) {
 
     try {
@@ -53,11 +68,16 @@ public class PubDocumentController {
   }
 
   @GetMapping
-  public ResponseEntity<ApiResponse<List<PubDocumentResponse>>> getDocuments(
-      @RequestParam(required = false) String studentId,
+  @Operation(summary = "Get PUB documents", description = "Get Prüfungsunfähigkeitsdokumente by student ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Documents retrieved successfully"),
+      @ApiResponse(responseCode = "400", description = "Student ID is required")
+  })
+  public ResponseEntity<ApiResponseWrapper<List<PubDocumentResponse>>> getDocuments(
+      @Parameter(description = "Student ID to filter documents", required = true) @RequestParam(required = false) String studentId,
       HttpServletRequest request) {
 
-    if (studentId == null || studentId.isEmpty()) {
+    if (studentId==null || studentId.isEmpty()) {
       return ResponseEntity.badRequest()
           .body(
               apiResponseFactory.badRequest(

--- a/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
+++ b/src/main/java/com/ase/exagrad/studentservice/controller/PubDocumentController.java
@@ -1,0 +1,77 @@
+package com.ase.exagrad.studentservice.controller;
+
+import com.ase.exagrad.studentservice.component.ApiResponseFactory;
+import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
+import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
+import com.ase.exagrad.studentservice.service.PubDocumentService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/documents/pub")
+@RequiredArgsConstructor
+public class PubDocumentController {
+
+  private final PubDocumentService pubDocumentService;
+  private final ApiResponseFactory apiResponseFactory;
+
+  @PostMapping(consumes = {"multipart/form-data"})
+  public ResponseEntity<ApiResponse<PubDocumentResponse>> uploadPubDocument(
+      @RequestPart("file") MultipartFile file,
+      @RequestPart("metadata") PubDocumentRequest metadata,
+      HttpServletRequest request) {
+
+    try {
+      PubDocumentResponse response = pubDocumentService.uploadPubDocument(file, metadata);
+
+      return ResponseEntity.status(HttpStatus.CREATED)
+          .body(apiResponseFactory.created(response, request.getRequestURI()));
+
+    }
+    catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest()
+          .body(apiResponseFactory.badRequest(e.getMessage(), request.getRequestURI()));
+    }
+    catch (IOException e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(
+              apiResponseFactory.internalServerError(
+                  "Upload failed: " + e.getMessage(), request.getRequestURI()));
+    }
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PubDocumentResponse>>> getDocuments(
+      @RequestParam(required = false) String studentId,
+      @RequestParam(required = false) String pubId,
+      HttpServletRequest request) {
+
+    if ((studentId != null && !studentId.isEmpty() && pubId != null && !pubId.isEmpty())
+        || ((studentId == null || studentId.isEmpty()) && (pubId == null || pubId.isEmpty()))) {
+      return ResponseEntity.badRequest()
+          .body(
+              apiResponseFactory.badRequest(
+                  "Provide exactly one parameter: studentId OR pubId",
+                  request.getRequestURI()));
+    }
+
+    List<PubDocumentResponse> documents =
+        (studentId != null && !studentId.isEmpty())
+            ? pubDocumentService.getDocumentsByStudentId(studentId)
+            : pubDocumentService.getDocumentsByPubId(pubId);
+
+    return ResponseEntity.ok(apiResponseFactory.success(documents, request.getRequestURI()));
+  }
+}

--- a/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
@@ -2,9 +2,10 @@ package com.ase.exagrad.studentservice.dto.request;
 
 import lombok.Data;
 
-//warum ist der dateiname noch rot? ;-;
 @Data
 public class PubDocumentRequest {
   private String pubId;
   private String studentId;
+  private String startDate;
+  private String endDate;
 }

--- a/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
@@ -1,0 +1,10 @@
+package com.ase.exagrad.studentservice.dto.request;
+
+import lombok.Data;
+
+//warum ist der dateiname noch rot? ;-;
+@Data
+public class PubDocumentRequest {
+  private String pubId;
+  private String studentId;
+}

--- a/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/request/PubDocumentRequest.java
@@ -4,7 +4,6 @@ import lombok.Data;
 
 @Data
 public class PubDocumentRequest {
-  private String pubId;
   private String studentId;
   private String startDate;
   private String endDate;

--- a/src/main/java/com/ase/exagrad/studentservice/dto/response/ApiResponseWrapper.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/response/ApiResponseWrapper.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ApiResponse<T> {
+public class ApiResponseWrapper<T> {
   private boolean success;
   private int statusCode;
   private String status;

--- a/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
@@ -1,0 +1,20 @@
+package com.ase.exagrad.studentservice.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+//warum ist der dateiname noch rot? ;-;
+@Data
+@Builder
+public class PubDocumentResponse {
+  private UUID id;
+  private String pubId;
+  private String studentId;
+  private ZonedDateTime uploadDate;
+  private String startDate; //change to another type?
+  private String endDate; //change to another type?
+  private String downloadUrl;
+  private String fileName;
+}

--- a/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
@@ -9,7 +9,6 @@ import lombok.Data;
 @Builder
 public class PubDocumentResponse {
   private UUID id;
-  private String pubId;
   private String studentId;
   private ZonedDateTime uploadDate;
   private String startDate;

--- a/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-//warum ist der dateiname noch rot? ;-;
 @Data
 @Builder
 public class PubDocumentResponse {
@@ -13,8 +12,8 @@ public class PubDocumentResponse {
   private String pubId;
   private String studentId;
   private ZonedDateTime uploadDate;
-  private String startDate; //change to another type?
-  private String endDate; //change to another type?
+  private String startDate;
+  private String endDate;
   private String downloadUrl;
   private String fileName;
 }

--- a/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
+++ b/src/main/java/com/ase/exagrad/studentservice/dto/response/PubDocumentResponse.java
@@ -1,9 +1,9 @@
 package com.ase.exagrad.studentservice.dto.response;
 
-import lombok.Builder;
-import lombok.Data;
 import java.time.ZonedDateTime;
 import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
 
 @Data
 @Builder

--- a/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
+++ b/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
@@ -39,10 +39,8 @@ public class PubDocument {
   @Column // nullable?
   private String endDate;
 
-  //Column for exams affected?
-
   @CreationTimestamp
-  @Column(nullable = false, updatable = false) //updatable false needed?
+  @Column(nullable = false, updatable = false)
   private Instant uploadDate;
 
   @Column(nullable = false, unique = true)

--- a/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
+++ b/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
@@ -1,0 +1,53 @@
+package com.ase.exagrad.studentservice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "pub_documents")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PubDocument {
+
+  @Id
+  @GeneratedValue
+  private UUID id;
+
+  @Column(nullable = false)
+  private String pubId;
+
+  @Column(nullable = false)
+  private String studentId;
+
+  @Column //nullable?
+  private String startDate;
+
+  @Column // nullable?
+  private String endDate;
+
+  //Column for exams affected?
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false) //updatable false needed?
+  private Instant uploadDate;
+
+  @Column(nullable = false, unique = true)
+  private String minioKey;
+
+  @Column(nullable = false)
+  private String fileName;
+}

--- a/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
+++ b/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
@@ -30,10 +30,10 @@ public class PubDocument {
   @Column(nullable = false)
   private String studentId;
 
-  @Column (nullable = false)
+  @Column(nullable = false)
   private String startDate;
 
-  @Column (nullable = false)
+  @Column(nullable = false)
   private String endDate;
 
   @CreationTimestamp

--- a/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
+++ b/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
@@ -1,5 +1,8 @@
 package com.ase.exagrad.studentservice.entity;
 
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,9 +13,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
-import java.time.Instant;
-import java.util.UUID;
 
 @Entity
 @Table(name = "pub_documents")
@@ -33,10 +33,10 @@ public class PubDocument {
   @Column(nullable = false)
   private String studentId;
 
-  @Column //nullable?
+  @Column (nullable = false)
   private String startDate;
 
-  @Column // nullable?
+  @Column (nullable = false)
   private String endDate;
 
   @CreationTimestamp

--- a/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
+++ b/src/main/java/com/ase/exagrad/studentservice/entity/PubDocument.java
@@ -28,9 +28,6 @@ public class PubDocument {
   private UUID id;
 
   @Column(nullable = false)
-  private String pubId;
-
-  @Column(nullable = false)
   private String studentId;
 
   @Column (nullable = false)

--- a/src/main/java/com/ase/exagrad/studentservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ase/exagrad/studentservice/exception/GlobalExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import com.ase.exagrad.studentservice.component.ApiResponseFactory;
 import com.ase.exagrad.studentservice.config.FileProperties;
-import com.ase.exagrad.studentservice.dto.response.ApiResponse;
+import com.ase.exagrad.studentservice.dto.response.ApiResponseWrapper;
 import com.ase.exagrad.studentservice.dto.response.ErrorDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
   private final FileProperties fileProperties;
 
   @ExceptionHandler(FileValidationException.class)
-  public ResponseEntity<ApiResponse<Void>> handleFileValidation(
+  public ResponseEntity<ApiResponseWrapper<Void>> handleFileValidation(
       FileValidationException ex, HttpServletRequest request) {
     log.warn("File validation error: {}", ex.getMessage());
 
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(StorageException.class)
-  public ResponseEntity<ApiResponse<Void>> handleStorage(
+  public ResponseEntity<ApiResponseWrapper<Void>> handleStorage(
       StorageException ex, HttpServletRequest request) {
     log.error("Storage error: {}", ex.getMessage(), ex);
 
@@ -63,7 +63,7 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(MaxUploadSizeExceededException.class)
-  public ResponseEntity<ApiResponse<Void>> handleMaxUploadSize(
+  public ResponseEntity<ApiResponseWrapper<Void>> handleMaxUploadSize(
       MaxUploadSizeExceededException ex, HttpServletRequest request) {
 
     long maxMB = DataSize.ofBytes(fileProperties.getMaxSize()).toMegabytes();
@@ -82,14 +82,14 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ApiResponse<Void>> handleGeneral(
+  public ResponseEntity<ApiResponseWrapper<Void>> handleGeneral(
       Exception ex, HttpServletRequest request) {
     log.error("Unexpected error occurred: {}", ex.getMessage(), ex);
 
     ErrorDetails error =
         ErrorDetails.builder()
             .code("INTERNAL_SERVER_ERROR")
-            .message("An unexpected error occurred")
+            .message("An unexpected error occurred" + ex.getMessage())
             .build();
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
+++ b/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
@@ -1,0 +1,27 @@
+package com.ase.exagrad.studentservice.mappers;
+
+import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
+import com.ase.exagrad.studentservice.entity.PubDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
+public class PubDocumentMapper {
+
+  private final ZoneId appZoneId;
+
+  public PubDocumentResponse toResponse(PubDocument entity, String downloadUrl) {
+    return PubDocumentResponse.builder()
+        .id(entity.getId())
+        .pubId(entity.getPubId())
+        .studentId(entity.getStudentId())
+        .uploadDate(entity.getUploadDate().atZone(appZoneId))
+        .startDate(entity.getStartDate())
+        .endDate(entity.getEndDate())
+        .downloadUrl(downloadUrl)
+        .fileName(entity.getFileName())
+        .build();
+  }
+}

--- a/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
+++ b/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
@@ -15,7 +15,6 @@ public class PubDocumentMapper {
   public PubDocumentResponse toResponse(PubDocument entity, String downloadUrl) {
     return PubDocumentResponse.builder()
         .id(entity.getId())
-        .pubId(entity.getPubId())
         .studentId(entity.getStudentId())
         .uploadDate(entity.getUploadDate().atZone(appZoneId))
         .startDate(entity.getStartDate())

--- a/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
+++ b/src/main/java/com/ase/exagrad/studentservice/mappers/PubDocumentMapper.java
@@ -1,10 +1,10 @@
 package com.ase.exagrad.studentservice.mappers;
 
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
 import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
 import com.ase.exagrad.studentservice.entity.PubDocument;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import java.time.ZoneId;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
+++ b/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
@@ -1,11 +1,10 @@
 package com.ase.exagrad.studentservice.repository;
 
-import com.ase.exagrad.studentservice.entity.PubDocument;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ase.exagrad.studentservice.entity.PubDocument;
 
-//wofür ist repository nochmal? fehlt was?
 public interface PubDocumentRepository extends JpaRepository<PubDocument, UUID> {
   List<PubDocument> findByStudentId(String studentId);
 }

--- a/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
+++ b/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
@@ -1,0 +1,13 @@
+package com.ase.exagrad.studentservice.repository;
+
+import com.ase.exagrad.studentservice.entity.PubDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.UUID;
+
+//wofür ist repository nochmal? fehlt was?
+public interface PubDocumentRepository extends JpaRepository<PubDocument, UUID> {
+  List<PubDocument> findByStudentId(String studentId);
+
+  List<PubDocument> findByPubId(String pubId);
+}

--- a/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
+++ b/src/main/java/com/ase/exagrad/studentservice/repository/PubDocumentRepository.java
@@ -8,6 +8,4 @@ import java.util.UUID;
 //wofür ist repository nochmal? fehlt was?
 public interface PubDocumentRepository extends JpaRepository<PubDocument, UUID> {
   List<PubDocument> findByStudentId(String studentId);
-
-  List<PubDocument> findByPubId(String pubId);
 }

--- a/src/main/java/com/ase/exagrad/studentservice/service/FileValidationService.java
+++ b/src/main/java/com/ase/exagrad/studentservice/service/FileValidationService.java
@@ -20,7 +20,7 @@ public class FileValidationService {
   private final FileProperties fileProperties;
 
   public void validateFile(MultipartFile file) {
-    if (file == null || file.isEmpty()) {
+    if (file==null || file.isEmpty()) {
       throw new FileValidationException("File is required and cannot be empty");
     }
 
@@ -30,7 +30,7 @@ public class FileValidationService {
   }
 
   private void validateFileName(String fileName) {
-    if (fileName == null || fileName.trim().isEmpty()) {
+    if (fileName==null || fileName.trim().isEmpty()) {
       throw new FileValidationException("File name is required");
     }
 
@@ -65,13 +65,13 @@ public class FileValidationService {
               "File size exceeds maximum allowed size of %d bytes", maxFileSize));
     }
 
-    if (size == 0) {
+    if (size==0) {
       throw new FileValidationException("File cannot be empty");
     }
   }
 
   private void validateContentType(String contentType) {
-    if (contentType == null) {
+    if (contentType==null) {
       throw new FileValidationException("Content type is required");
     }
 
@@ -87,7 +87,7 @@ public class FileValidationService {
     }
 
     for (int i = 0; i < signature.length; i++) {
-      if (data[i] != signature[i]) {
+      if (data[i]!=signature[i]) {
         return false;
       }
     }
@@ -96,11 +96,11 @@ public class FileValidationService {
 
   private String getFileExtension(String fileName) {
     int lastDotIndex = fileName.lastIndexOf('.');
-    return lastDotIndex > 0 ? fileName.substring(lastDotIndex + 1) : "";
+    return lastDotIndex > 0 ? fileName.substring(lastDotIndex + 1):"";
   }
 
   public String sanitizeFileName(String fileName) {
-    if (fileName == null) {
+    if (fileName==null) {
       return "unnamed_file";
     }
     return fileName.replaceAll("[\\\\/:*?\"<>|]", "_").replaceAll("\\s+", "_").trim();

--- a/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
+++ b/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
@@ -1,0 +1,86 @@
+package com.ase.exagrad.studentservice.service;
+
+import com.ase.exagrad.studentservice.config.StorageProperties;
+import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
+import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
+import com.ase.exagrad.studentservice.entity.PubDocument;
+import com.ase.exagrad.studentservice.mappers.PubDocumentMapper;
+import com.ase.exagrad.studentservice.repository.PubDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.time.Year;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PubDocumentService {
+
+  private final PubDocumentRepository pubDocumentRepository;
+  private final MinioService minioService;
+  private final StorageProperties storageProperties;
+  private final FileValidationService fileValidationService;
+  private final PubDocumentMapper pubDocumentMapper;
+
+  @Transactional
+  public PubDocumentResponse uploadPubDocument(MultipartFile file, PubDocumentRequest metadata)
+      throws IOException {
+    // Validate file before processing
+    fileValidationService.validateFile(file);
+
+    String bucketName = storageProperties.getPubDocumentsBucket();
+    String sanitizedFilename =
+        fileValidationService.sanitizeFileName(file.getOriginalFilename());
+    String minioKey = generateMinioKey(sanitizedFilename);
+
+    minioService.uploadFile(
+        bucketName, minioKey, file.getInputStream(), file.getSize(), file.getContentType());
+
+    PubDocument doc = //needs start and end date?
+        PubDocument.builder()
+            .pubId(metadata.getPubId())
+            .studentId(metadata.getStudentId())
+            .minioKey(minioKey)
+            .fileName(sanitizedFilename)
+            .build();
+
+    PubDocument saved = pubDocumentRepository.saveAndFlush(doc);
+
+    String downloadUrl = minioService.getFileUrl(bucketName, saved.getMinioKey());
+    return pubDocumentMapper.toResponse(saved, downloadUrl);
+  }
+
+  public List<PubDocumentResponse> getDocumentsByStudentId(String studentId) {
+    List<PubDocument> documents = pubDocumentRepository.findByStudentId(studentId);
+    return convertToResponseWithUrls(documents);
+  }
+
+  public List<PubDocumentResponse> getDocumentsByPubId(String pubId) {
+    List<PubDocument> documents = pubDocumentRepository.findByPubId(pubId);
+    return convertToResponseWithUrls(documents);
+  }
+
+  private List<PubDocumentResponse> convertToResponseWithUrls(List<PubDocument> documents) {
+    String bucketName = storageProperties.getPubDocumentsBucket();
+
+    return documents.stream()
+        .map(
+            doc -> {
+              String downloadUrl =
+                  minioService.getFileUrl(bucketName, doc.getMinioKey());
+              return pubDocumentMapper.toResponse(doc, downloadUrl);
+            })
+        .toList();
+  }
+
+  private String generateMinioKey(String originalFilename) {
+    String year = String.valueOf(Year.now().getValue());
+    String unique = UUID.randomUUID().toString();
+    return "pub-documents/" + year + "/" + unique + "-" + originalFilename;
+  }
+}

--- a/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
+++ b/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
@@ -41,10 +41,12 @@ public class PubDocumentService {
     minioService.uploadFile(
         bucketName, minioKey, file.getInputStream(), file.getSize(), file.getContentType());
 
-    PubDocument doc = //needs start and end date?
+    PubDocument doc =
         PubDocument.builder()
             .pubId(metadata.getPubId())
             .studentId(metadata.getStudentId())
+            .startDate(metadata.getStartDate())
+            .endDate(metadata.getEndDate())
             .minioKey(minioKey)
             .fileName(sanitizedFilename)
             .build();
@@ -57,11 +59,6 @@ public class PubDocumentService {
 
   public List<PubDocumentResponse> getDocumentsByStudentId(String studentId) {
     List<PubDocument> documents = pubDocumentRepository.findByStudentId(studentId);
-    return convertToResponseWithUrls(documents);
-  }
-
-  public List<PubDocumentResponse> getDocumentsByPubId(String pubId) {
-    List<PubDocument> documents = pubDocumentRepository.findByPubId(pubId);
     return convertToResponseWithUrls(documents);
   }
 

--- a/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
+++ b/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
@@ -1,5 +1,12 @@
 package com.ase.exagrad.studentservice.service;
 
+import java.io.IOException;
+import java.time.Year;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import com.ase.exagrad.studentservice.config.StorageProperties;
 import com.ase.exagrad.studentservice.dto.request.PubDocumentRequest;
 import com.ase.exagrad.studentservice.dto.response.PubDocumentResponse;
@@ -8,13 +15,6 @@ import com.ase.exagrad.studentservice.mappers.PubDocumentMapper;
 import com.ase.exagrad.studentservice.repository.PubDocumentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
-import java.time.Year;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
+++ b/src/main/java/com/ase/exagrad/studentservice/service/PubDocumentService.java
@@ -43,7 +43,6 @@ public class PubDocumentService {
 
     PubDocument doc =
         PubDocument.builder()
-            .pubId(metadata.getPubId())
             .studentId(metadata.getStudentId())
             .startDate(metadata.getStartDate())
             .endDate(metadata.getEndDate())


### PR DESCRIPTION
This PR integrates springdoc-openapi-starter-webmvc-ui into our Spring Boot backend to generate and expose OpenAPI documentation via Swagger UI.
The goal is to:

- Expose /v3/api-docs and /swagger-ui.html

- Provide interactive documentation and request testing

- Review all endpoints, request/response models, and HTTP status codes in detail

Current Focus for Review

 - Validate OpenAPI annotations and that descriptions are meaningful

 - Verify response codes (200, 201, 400, 404, 500, etc.) are correctly reflected in the spec

 - Check content types (e.g., avoid application/octet-stream being allowed by default in Bruno or Swagger "Try it out")

 - Ensure models (DTOs) are documented properly with field descriptions

 - Confirm interactive "Try it out" works as expected without misleading defaults
