### PR TITLE
fix: Copy checkstyle.xml to Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM maven:3.9.5-eclipse-temurin-21 AS build
 WORKDIR /app
 
 COPY pom.xml .
+COPY checkstyle.xml .
 RUN mvn -B -q dependency:go-offline
 
 COPY src ./src


### PR DESCRIPTION
## Problem
The Docker build was failing with:
```
Failed during checkstyle execution: Unable to find configuration file at location: checkstyle.xml: Could not find resource 'checkstyle.xml'.
```

## Solution
Added `COPY checkstyle.xml .` to the Dockerfile build stage to ensure the checkstyle configuration file is available when Maven runs the checkstyle plugin.

## Changes
- Added checkstyle.xml copy instruction to Dockerfile before dependency download

## Testing
This fix allows the Docker build to complete successfully by ensuring all required configuration files are present in the build context.